### PR TITLE
[β-0] feat: add encrypted Slack & GH token secrets

### DIFF
--- a/secrets/env.yaml
+++ b/secrets/env.yaml
@@ -1,0 +1,17 @@
+slack_webhook_url: https://hooks.slack.com/services/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
+gh_agent_token: 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
+sops:
+    age:
+        - recipient: age1v9g5u6a5mpnt95cf9xvqesamxclqc4e3ztens5caghda6d0agehs8hrk6y
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBiSnY1WmN2ZTVYSEFVYXht
+            ZjczdmlaQTlvRURtQXFvTGxXQnFWTUR2S3k4CnpJNTJyWFJacFZiQ251RWtpeGkr
+            Y1E1UFNRZC9LSGJJQUJLbWljZCtJbkkKLS0tIGN3ZG1mSW03M0x5SWNFSjFmdExC
+            SC9OWEJEN0lqNDJjbVYwcWNJVHNiWjgKyJ4eugGuVIWnQ1oIrRKMlPitfQA6IAYd
+            1Vya2pd8lLlLppYsQLtI79LBb92DVtAZvqAI83AeEsJ8TB7l7vTjtw==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2025-08-06T20:53:27Z"
+    mac: ENC[AES256_GCM,data:dhH0xZ66Itq4DcVKbPwmVFU3zVgg7VcA8yDSyXF2ihAFt4ROsPD7Tc8QV85tP9kcxSBk+xtgXBLjVaRcswPf6VHR8BxBeghsWenDE6UOxZ8VcIH6y4xhdXp4+1qS74x+JOVUdt+YyOW7VQjqHs9HZCDZUdBZtXBksYKWlYWt9ko=,iv:DoELYwocUdA/93lNiv+mP+49SJsuJ10RpwlCSxMaOYw=,tag:GPxaq+YbKqkER5Wyh0XXlw==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.10.2

--- a/secrets/env.yaml
+++ b/secrets/env.yaml
@@ -5,13 +5,13 @@ sops:
         - recipient: age1v9g5u6a5mpnt95cf9xvqesamxclqc4e3ztens5caghda6d0agehs8hrk6y
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQcXQwdDQxNERiNysyOW1K
-            RVY4Sk5iaW8wODM3VERpMGczRjAxeXJrNmlVCmhIVTVrZXNhVEhBL21RMEZJSW9Q
-            YjVKaVNQdW12MUt5cDI2a0twejRHT00KLS0tIDlVeThLNE9wS2VpaDR5VXNaUk9k
-            MlN3dWRHblFHRDFxbFJxSDVxUEhKMWMKg3Fq82b9tDukf1K8AV4z6XkRDz3t62HR
-            WR1FxCK3/AlIKr6RXf3E7uMv/8JMvOjIUjB8ZF2tN+U+rOdpdlsSWQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA0VjBJWlBLdklBRVdPTGU5
+            RWZwSWszbjA5amNLRDluS3BLaXdaQ2I4NGgwClJMT0YrajZkZzVIbFg3VkRDeXcx
+            MVZpYy9iSjV4MjRWZ0lSVTBPUTlqTGMKLS0tIDNMZEEyd0FLdTE3UWFCdW9TQTBX
+            ZGZjUUpndnBUSDBLNWNQUWFCSVgxa0EKNstg+Tgo6U5L4SkPdXABALjEYesYOxYO
+            Qza+4dCSZfEJrVpn8TjfU23JHyWGvGqtB+g9ldxWFR5u8IE83zsqOA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2025-08-06T20:57:22Z"
-    mac: ENC[AES256_GCM,data:lZ1aarUyZr2mh7zvsMGjczdhLe1+kLEMwxsE4dRHEHesypy0gSKxBto8AdVKTnHpih9Yd168B9hVRAS6hgxU26rgcPdDEF+F4RrVfyJqbV9WbSEAeb+NO/dkbz11lc236uPdhRk77i/6V+zrdRhU6LXhvu2n3bsP3jvckH3XhC0=,iv:CAHIVHUr0UctF0OnxgAOWWYKDChTzjHU1UyT5wdwdd8=,tag:BGEi4LN21dG45nxGTnoiyw==,type:str]
+    lastmodified: "2025-08-06T20:59:55Z"
+    mac: ENC[AES256_GCM,data:b3+vmxMmOB4lPbGg35A4rkEeheJycRZmHZPSVOCS/BdETi+G5g4uo/A0iGxrG9mNnmrnWrZkVUazeF+uucq5Sh5yptezn0lhhgtEsfSuRCvepXk2fDgrMF962bPDWr+StZDX6lsnl/nPGP9Y4qC8fvmw78575bDqNX9hsSIZPxk=,iv:0JN/CA6eIKorGUs8mGl9FxaQpsOdsD46Lwh0GzQMK7w=,tag:9pZLuj9ogw/Cbt0SOdI+Aw==,type:str]
     encrypted_regex: ^(data|stringData)$
     version: 3.10.2

--- a/secrets/env.yaml
+++ b/secrets/env.yaml
@@ -5,13 +5,13 @@ sops:
         - recipient: age1v9g5u6a5mpnt95cf9xvqesamxclqc4e3ztens5caghda6d0agehs8hrk6y
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBiSnY1WmN2ZTVYSEFVYXht
-            ZjczdmlaQTlvRURtQXFvTGxXQnFWTUR2S3k4CnpJNTJyWFJacFZiQ251RWtpeGkr
-            Y1E1UFNRZC9LSGJJQUJLbWljZCtJbkkKLS0tIGN3ZG1mSW03M0x5SWNFSjFmdExC
-            SC9OWEJEN0lqNDJjbVYwcWNJVHNiWjgKyJ4eugGuVIWnQ1oIrRKMlPitfQA6IAYd
-            1Vya2pd8lLlLppYsQLtI79LBb92DVtAZvqAI83AeEsJ8TB7l7vTjtw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBQcXQwdDQxNERiNysyOW1K
+            RVY4Sk5iaW8wODM3VERpMGczRjAxeXJrNmlVCmhIVTVrZXNhVEhBL21RMEZJSW9Q
+            YjVKaVNQdW12MUt5cDI2a0twejRHT00KLS0tIDlVeThLNE9wS2VpaDR5VXNaUk9k
+            MlN3dWRHblFHRDFxbFJxSDVxUEhKMWMKg3Fq82b9tDukf1K8AV4z6XkRDz3t62HR
+            WR1FxCK3/AlIKr6RXf3E7uMv/8JMvOjIUjB8ZF2tN+U+rOdpdlsSWQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2025-08-06T20:53:27Z"
-    mac: ENC[AES256_GCM,data:dhH0xZ66Itq4DcVKbPwmVFU3zVgg7VcA8yDSyXF2ihAFt4ROsPD7Tc8QV85tP9kcxSBk+xtgXBLjVaRcswPf6VHR8BxBeghsWenDE6UOxZ8VcIH6y4xhdXp4+1qS74x+JOVUdt+YyOW7VQjqHs9HZCDZUdBZtXBksYKWlYWt9ko=,iv:DoELYwocUdA/93lNiv+mP+49SJsuJ10RpwlCSxMaOYw=,tag:GPxaq+YbKqkER5Wyh0XXlw==,type:str]
+    lastmodified: "2025-08-06T20:57:22Z"
+    mac: ENC[AES256_GCM,data:lZ1aarUyZr2mh7zvsMGjczdhLe1+kLEMwxsE4dRHEHesypy0gSKxBto8AdVKTnHpih9Yd168B9hVRAS6hgxU26rgcPdDEF+F4RrVfyJqbV9WbSEAeb+NO/dkbz11lc236uPdhRk77i/6V+zrdRhU6LXhvu2n3bsP3jvckH3XhC0=,iv:CAHIVHUr0UctF0OnxgAOWWYKDChTzjHU1UyT5wdwdd8=,tag:BGEi4LN21dG45nxGTnoiyw==,type:str]
     encrypted_regex: ^(data|stringData)$
     version: 3.10.2


### PR DESCRIPTION
This adds the encrypted Slack webhook and GitHub token for β-0.